### PR TITLE
feat: 🎸 better aliases system + userPermissions types

### DIFF
--- a/src/client/Client.ts
+++ b/src/client/Client.ts
@@ -24,7 +24,6 @@ const globPromise = promisify(glob);
 class Spencer extends Client {
 	public logger: Consola = consola;
 	public commands: Collection<string, Command> = new Collection();
-	public aliases: Collection<string, string> = new Collection();
 	public cooldowns: Collection<string, number> = new Collection();
 	public schemas: Collection<string, Schema> = new Collection();
 	public categories: Set<string> = new Set();
@@ -74,9 +73,6 @@ class Spencer extends Client {
 		commandFiles.map(async (cmdFile: string) => {
 			const cmd = (await import(cmdFile)) as Command;
 			this.commands.set(cmd.name, { cooldown: 3000, ...cmd });
-			if (cmd.aliases) {
-				cmd.aliases.map((alias: string) => this.aliases.set(alias, cmd.name));
-			}
 			this.categories.add(cmd.category);
 		});
 		eventFiles.map(async (eventFile: string) => {

--- a/src/commands/Info Commands/HelpCommand.ts
+++ b/src/commands/Info Commands/HelpCommand.ts
@@ -38,7 +38,7 @@ export const run: RunFunction = async (client, message, args) => {
 			.has(args[0].toLowerCase()) &&
 		!client.commands
 			.filter((value: Command) => value.category != 'owner')
-			.has(client.aliases.get(args[0].toLowerCase()))
+			.find((c) => c.aliases?.includes(args[0].toLowerCase()))
 	)
 		return message.channel.send(commandEmbed);
 	const command =
@@ -47,7 +47,7 @@ export const run: RunFunction = async (client, message, args) => {
 			.get(args[0].toLowerCase()) ||
 		client.commands
 			.filter((value: Command) => value.category != 'owner')
-			.get(client.aliases.get(args[0].toLowerCase()));
+			.find((c) => c.aliases?.includes(args[0].toLowerCase()));
 	message.channel.send(
 		client.embed(
 			{

--- a/src/events/Guild Events/MessageEvent.ts
+++ b/src/events/Guild Events/MessageEvent.ts
@@ -130,7 +130,7 @@ export const run: RunFunction = async (client, message: Message) => {
 		.split(/ +/g);
 	const command: Anything =
 		client.commands.get(cmd.toLowerCase()) ||
-		client.commands.get(client.aliases.get(cmd.toLowerCase()));
+		client.commands.find((c) => c.aliases?.includes(cmd.toLowerCase()));
 	if (client.config.onlyUsed) {
 		if (!client.config.onlyUsed.includes(message.author.id)) return;
 	}
@@ -143,7 +143,10 @@ export const run: RunFunction = async (client, message: Message) => {
 		) {
 			const best: string[] = [
 				...client.commands.map((value: Command) => value.name),
-				...client.aliases.map((value: string, key: string) => key),
+				...client.commands.reduce((a, v) => {
+					if (v.aliases) return [...a, ...v.aliases];
+					return a;
+				}, []),
 			].filter(
 				(input: string) =>
 					leven(cmd.toLowerCase(), input.toLowerCase()) < input.length * 0.4

--- a/src/interfaces/Command.ts
+++ b/src/interfaces/Command.ts
@@ -1,4 +1,4 @@
-import { Message } from 'discord.js';
+import { Message, PermissionResolvable } from 'discord.js';
 import { Spencer } from '../client/Client';
 
 export interface RunFunction {
@@ -11,7 +11,7 @@ export interface Command {
 	description: string;
 	cooldown?: number;
 	category: string;
-	userPermissions?: string | string[];
+	userPermissions?: PermissionResolvable | PermissionResolvable[];
 	ownerOnly?: boolean;
 	usage?: string;
 }


### PR DESCRIPTION
- Aliases are no longer a separate collection, reducing memory by simply finding aliases using `client.commands.find()`
- userPermissions now have `PermissionResolvable | PermissionResolvable[]` instead of `string | string[]`

**Changes are tested!. 🔫**